### PR TITLE
Set build exclusion paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,11 @@ env:
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - .github/workflows/**
+      - README.md
+      - LICENSE*
+      - .gitignore
   workflow_dispatch:
   
 jobs:


### PR DESCRIPTION
Dont' run build CI when the push only contains changes in:
- `.github/workflows/**`
- `README.md`
- `LICENSE*`
- `.gitignore`